### PR TITLE
⬆️ Update templating action to v1.5.0

### DIFF
--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -24,7 +24,7 @@ jobs:
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           permission-contents: write # Needed to push the templating branch
           permission-pull-requests: write # Needed to open the templating pull request
-      - uses: munich-quantum-toolkit/templates@f87a5f152d33b64e3cc4fad41c402bf7ce892f5d # v1.4.3
+      - uses: munich-quantum-toolkit/templates@8caeb0bd8d0e2ebf906e7c3a826c06f72844a83b # v1.5.0
         with:
           token: ${{ steps.create-token.outputs.token }}
           name: DDVis

--- a/.github/workflows/templating.yml
+++ b/.github/workflows/templating.yml
@@ -34,4 +34,5 @@ jobs:
           has-changelog-and-upgrade-guide: false
           synchronize-contribution-guide: false
           synchronize-documentation-utilities: false
+          synchronize-gitignore: false
           synchronize-installation-guide: false

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,79 @@
-node_modules
-build
-public/data/*
-.idea
-cmake-build-*
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+
+# Packaging
+/build/
+/dist/
+.eggs/
+*.egg
+*.egg-info/
+/_skbuild/
+/wheelhouse/
+
+# Testing
+.coverage
+.coverage.*
+.hypothesis/
+.nox/
+.pytest_cache/
+.tox/
+*.cover
+*.profraw
+coverage.xml
+htmlcov/
+
+# Documentation
+docs/_build/
+docs/**/build/
+docs/api/
+
+# Environments
+.env
+.env.*
+!.env.example
+!.env.*.example
 .venv/
+env/
 venv/
+
+# Tool caches
+.cache/
+.mypy_cache/
+.pyre/
+.pytype/
+.ruff_cache/
+.rumdl_cache/
+
+# Jupyter
+.ipynb_checkpoints/
+
+# Versioning
+python/**/_version.py
+src/**/_version.py
+
+# Editors
+.idea/
+.vs/
+.vscode/
+*.swp
+*~
+
+# Claude
+.claude/
+CLAUDE.md
+
+# Operating systems
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+Thumbs.db
+ehthumbs.db
+
+# Custom
+/cmake-build-*/
+/node_modules/


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Update the [munich-quantum-toolkit/templates](https://github.com/munich-quantum-toolkit/templates) action to v1.5.0. Align the local `.gitignore` with the shared base while retaining root CMake IDE build directories and Node.js dependencies in a custom section. Remove the stale public-data rule. Keep `.gitignore` synchronization explicitly disabled because the shared template does not cover these repository-specific rules.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.
